### PR TITLE
Feat/init : init관련 로직 구현 

### DIFF
--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -2,6 +2,7 @@
 #define VM_VM_H
 #include <stdbool.h>
 
+#include "lib/kernel/hash.h"
 #include "threads/palloc.h"
 
 enum vm_type {
@@ -35,7 +36,7 @@ enum vm_type {
 struct page_operations;
 struct thread;
 
-#define VM_TYPE(type) ((type)&7)
+#define VM_TYPE(type) ((type) & 7)
 
 /* The representation of "page".
  * This is kind of "parent class", which has four "child class"es, which are
@@ -46,7 +47,8 @@ struct page {
   void *va;            /* Address in terms of user space */
   struct frame *frame; /* Back reference for frame */
 
-  /* Your implementation */
+  struct hash_elem hash_elem;
+  bool writable;
 
   /* Per-type data are binded into the union.
    * Each function automatically detects the current union */
@@ -85,7 +87,9 @@ struct page_operations {
 /* Representation of current process's memory space.
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
-struct supplemental_page_table {};
+struct supplemental_page_table {
+  struct hash page_table;
+};
 
 #include "threads/thread.h"
 void supplemental_page_table_init(struct supplemental_page_table *spt);
@@ -109,4 +113,4 @@ void vm_dealloc_page(struct page *page);
 bool vm_claim_page(void *va);
 enum vm_type page_get_type(struct page *page);
 
-#endif /* VM_VM_H */
+#endif

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -44,6 +44,16 @@ static struct semaphore initd_sema;
 // extern → 다른 파일에 정의된 전역 변수를 여기서 참조하겠다는 의미
 extern bool thread_tests; /* threads/init.c 파일 안에서 정의되어 있다 */
 
+#ifdef VM
+struct lazy_load_aux {
+  struct file *file;
+  off_t ofs;
+  size_t page_read_bytes;
+  size_t page_zero_bytes;
+};
+
+#endif
+
 /* General process initializer for initd and other process. */
 static void process_init(void) {
   struct thread *current = thread_current();
@@ -58,7 +68,7 @@ static void process_init(void) {
 
   // 표준 입출력 0~2(stdin, stdout, stderr)를 건너뛰고, 일반 파일 fd는 3부터
   // 할당한다.
-  current->next_FD = 3;  // 다음에 배정할 파일 디스크립터 시작값 지정
+  current->next_FD = 3;       // 다음에 배정할 파일 디스크립터 시작값 지정
   current->stdin_count = 1;   // 기본 STDIN 하나가 열려 있음을 표시
   current->stdout_count = 1;  // 기본 STDOUT 하나가 열려 있음을 표시
   current->FDT[STDIN_FILENO] =
@@ -147,7 +157,7 @@ tid_t process_fork(const char *name, struct intr_frame *if_ UNUSED) {
   // 자식 초기화가 실패했다면 부모는 fork 실패로 처리
   if (child->fork_status != 0) {
     list_remove(&child->child_elem);  // 부모 children 리스트에서 제거
-    sema_up(&child->exit_sema);  // 자식이 종료 루틴을 마칠 수 있게 깨움
+    sema_up(&child->exit_sema);       // 자식이 종료 루틴을 마칠 수 있게 깨움
     return TID_ERROR;
   }
 
@@ -275,12 +285,12 @@ static void __do_fork(void *aux) {
     }
     if (parent_file == stdin_file) {
       current->FDT[fd] = stdin_file;  // STDIN 더미 포인터 공유
-      current->stdin_count++;  // 자식이 보유한 STDIN 참조 수 누적
+      current->stdin_count++;         // 자식이 보유한 STDIN 참조 수 누적
       continue;
     }
     if (parent_file == stdout_file) {
       current->FDT[fd] = stdout_file;  // STDOUT 더미 포인터 공유
-      current->stdout_count++;  // 자식이 보유한 STDOUT 참조 수 누적
+      current->stdout_count++;         // 자식이 보유한 STDOUT 참조 수 누적
       continue;
     }
     current->FDT[fd] =
@@ -564,7 +574,7 @@ static bool load(const char *file_name, struct intr_frame *if_) {
     goto done;
   }
 
-  file_deny_write(file);  // 현재 실행중인 파일 쓰기 금지
+  file_deny_write(file);   // 현재 실행중인 파일 쓰기 금지
   t->running_file = file;  // 스레드의 running_file을 현재 파일로 설정
 
   /* Read and verify executable header. */
@@ -791,9 +801,9 @@ static void argument_stack(char *argv[], int argc, struct intr_frame *_if) {
 
   // 문자열을 스택에 역순으로 복사
   for (int i = argc - 1; i >= 0; i--) {
-    size_t len = strlen(argv[i]) + 1;  // 문자열 길이 + 널 문자 포함
-    _if->rsp -= len;                   // 스택 아래로 공간 확보
-    rsp_arr[i] = _if->rsp;  // 해당 문자열이 위치한 주소 저장
+    size_t len = strlen(argv[i]) + 1;        // 문자열 길이 + 널 문자 포함
+    _if->rsp -= len;                         // 스택 아래로 공간 확보
+    rsp_arr[i] = _if->rsp;                   // 해당 문자열이 위치한 주소 저장
     memcpy((void *)_if->rsp, argv[i], len);  // 스택에 문자열 복사
   }
 
@@ -810,7 +820,7 @@ static void argument_stack(char *argv[], int argc, struct intr_frame *_if) {
   }
 
   // NULL sentinel push (argv[argc] = NULL)
-  _if->rsp -= 8;  // 포인터 크기만큼 스택 아래로
+  _if->rsp -= 8;                                // 포인터 크기만큼 스택 아래로
   memset((void *)_if->rsp, 0, sizeof(char *));  // 0으로 채움 (NULL)
 
   // argv[i] 포인터들을 역순으로 push
@@ -835,7 +845,7 @@ static void argument_stack(char *argv[], int argc, struct intr_frame *_if) {
 
 struct thread *get_child_thread(tid_t child_tid) {
   struct thread *current_thread =
-      thread_current();  // 현재 실행 중인 스레드(=부모 스레드)를 가져옴
+      thread_current();          // 현재 실행 중인 스레드(=부모 스레드)를 가져옴
   struct thread *result = NULL;  // 결과를 저장할 포인터
 
   // 현재 스레드의 자식 리스트를 순회함
@@ -917,6 +927,7 @@ static bool lazy_load_segment(struct page *page, void *aux) {
   /* TODO: Load the segment from the file */
   /* TODO: This called when the first page fault occurs on address VA. */
   /* TODO: VA is available when calling this function. */
+  free(aux);
 }
 
 /* Loads a segment starting at offset OFS in FILE at address
@@ -948,7 +959,11 @@ static bool load_segment(struct file *file, off_t ofs, uint8_t *upage,
     size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
     /* TODO: Set up aux to pass information to the lazy_load_segment. */
-    void *aux = NULL;
+    struct lazy_load_aux *aux = malloc(sizeof(struct lazy_load_aux));
+    aux->file = file;
+    aux->page_read_bytes = page_read_bytes;
+    aux->page_zero_bytes = page_zero_bytes;
+    aux->ofs = ofs;
     if (!vm_alloc_page_with_initializer(VM_ANON, upage, writable,
                                         lazy_load_segment, aux))
       return false;
@@ -956,6 +971,7 @@ static bool load_segment(struct file *file, off_t ofs, uint8_t *upage,
     /* Advance. */
     read_bytes -= page_read_bytes;
     zero_bytes -= page_zero_bytes;
+    ofs += page_read_bytes;
     upage += PGSIZE;
   }
   return true;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -5,6 +5,9 @@
 #include "threads/malloc.h"
 #include "vm/inspect.h"
 
+struct list frame_list;
+struct lock frame_lock;
+
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
 void vm_init(void) {
@@ -15,7 +18,8 @@ void vm_init(void) {
 #endif
   register_inspect_intr();
   /* DO NOT MODIFY UPPER LINES. */
-  /* TODO: Your code goes here. */
+  list_init(&frame_list);
+  lock_init(&frame_lock);
 }
 
 /* Get the type of the page. This function is useful if you want to know the
@@ -48,6 +52,30 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
 
   /* Check wheter the upage is already occupied or not. */
   if (spt_find_page(spt, upage) == NULL) {
+    struct page *page = malloc(sizeof(struct page));
+    if (page == NULL) {
+      goto err;
+    }
+
+    page->va = upage;
+    page->writable = writable;
+
+    bool (*initializer)(struct page *, enum vm_type, void *kva) = NULL;
+    switch (VM_TYPE(type)) {
+      case VM_ANON:
+        initializer = anon_initializer;
+        break;
+      case VM_FILE:
+        initializer = file_backed_initializer;
+        break;
+
+      default:
+        free(page);
+        goto err;
+    }
+
+    uninit_new(page, upage, init, type, aux, initializer);
+
     /* TODO: Create the page, fetch the initialier according to the VM type,
      * TODO: and then create "uninit" page struct by calling uninit_new. You
      * TODO: should modify the field after calling the uninit_new. */

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -163,8 +163,14 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
                          bool not_present UNUSED) {
   struct supplemental_page_table *spt UNUSED = &thread_current()->spt;
   struct page *page = NULL;
-  /* TODO: Validate the fault */
-  /* TODO: Your code goes here */
+  if (addr == NULL || is_kernel_vaddr(addr) || not_present) {
+    return false;
+  }
+
+  page = spt_find_page(spt, addr);
+  if (page == NULL) {
+    return false;
+  }
 
   return vm_do_claim_page(page);
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -3,6 +3,7 @@
 #include "vm/vm.h"
 
 #include "threads/malloc.h"
+#include "threads/mmu.h"
 #include "vm/inspect.h"
 
 struct list frame_list;
@@ -75,12 +76,10 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
     }
 
     uninit_new(page, upage, init, type, aux, initializer);
-
-    /* TODO: Create the page, fetch the initialier according to the VM type,
-     * TODO: and then create "uninit" page struct by calling uninit_new. You
-     * TODO: should modify the field after calling the uninit_new. */
-
-    /* TODO: Insert the page into the spt. */
+    if (!spt_insert_page(spt, page)) {
+      free(page);
+      goto err;
+    }
   }
 err:
   return false;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -98,7 +98,13 @@ struct page *spt_find_page(struct supplemental_page_table *spt UNUSED,
 bool spt_insert_page(struct supplemental_page_table *spt UNUSED,
                      struct page *page UNUSED) {
   int succ = false;
-  /* TODO: Fill this function. */
+
+  struct hash_elem *result_elem =
+      hash_insert(&spt->page_table, &page->hash_elem);
+
+  if (result_elem == &page->hash_elem) {
+    succ = true;
+  }
 
   return succ;
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -89,7 +89,14 @@ err:
 struct page *spt_find_page(struct supplemental_page_table *spt UNUSED,
                            void *va UNUSED) {
   struct page *page = NULL;
-  /* TODO: Fill this function. */
+  struct hash_elem *e = NULL;
+
+  page->va = va;
+
+  e = hash_find(&spt->page_table, &page->hash_elem);
+  if (e != NULL) {
+    page = hash_entry(e, struct page, hash_elem);
+  }
 
   return page;
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -199,6 +199,7 @@ static bool vm_do_claim_page(struct page *page) {
   page->frame = frame;
 
   /* TODO: Insert page table entry to map page's VA to frame's PA. */
+  pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable);
 
   return swap_in(page, frame->kva);
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -186,7 +186,9 @@ static bool vm_do_claim_page(struct page *page) {
 }
 
 /* Initialize new supplemental page table */
-void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED) {}
+void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED) {
+  hash_init(&spt->page_table, hash_hash_func, hash_less_func, NULL);
+}
 
 /* Copy supplemental page table from src to dst */
 bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
@@ -196,4 +198,16 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
 void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED) {
   /* TODO: Destroy all the supplemental_page_table hold by thread and
    * TODO: writeback all the modified contents to the storage. */
+}
+
+static uint64_t hash_hash_func(const struct hash_elem *e, void *aux) {
+  struct page *p = hash_entry(e, struct page, hash_elem);
+  return hash_bytes(&p->va, sizeof(p->va));
+}
+
+static bool hash_less_func(const struct hash_elem *a, const struct hash_elem *b,
+                           void *aux) {
+  struct page *p1 = hash_entry(a, struct page, hash_elem);
+  struct page *p2 = hash_entry(a, struct page, hash_elem);
+  return p1->va < p2->va;
 }


### PR DESCRIPTION
# 목표 
컴퓨터 부팅 시 처리되는 init관련 로직을 Project 3 VM버전으로 변경 

*(Lazy_Load와 stack 설정은 이후에 구현할 예정)*

# 구현 
## supplemental_page_table 구조체 변경 및 init 로직 
> PF시 사용할 SPT 테이블 설정 

- hash 테이블로 구현 
  - 조회 시 유리한 자료구조인 hash 사용해서 테이블 구현 
- supplemental_page_table_init 구현
  - hash_init 추가
  - hash_hash_func 구현
  - hash_less_func 구현

## lazy_load_aux 구조체 구현 및 활용
> PF시 로드하는 예약 함수인 lazy_load_segement에 넘겨줄 구조체 설정

- lazy_load_segment함수에 넘겨줄 aux 변수 구조체 설정
- 넘겨줄 aux 구조체에 file, read_bytes, zero_bytes, offset 초기화 

## vm_alloc_page_with_initializer 구현 
> 목적 : 페이지를 생성하고 초기화하는 **과정을 예약**
1. spt_find_page를 통한 spt내 va에 해당하는 page가 존재하는지 여부 확인 (없어야 할당)
2.  page 구조체 생성 및 초기화 - 가상주소, r/w, initializer(타입별)
3. 2번에서 만든 page를 uninit 페이지로 설정
4. 3번까지 만든 page를 spt에 insert

## frame 테이블 설정
- 목적 : frame들을 관리하는 테이블 설정 
- frame_list, frame_lock 설정
- init으로 초기화 

## 번외 : PF 시 로직 아주 일부 구현
### `vm_try_handle_fault`
- 주소 검증
- 해당 주소에 맞는 page 조회 in SPT

### `vm_do_claim_page` 
- pml4_set_page : user va와 kernel va 매핑 
