### PR TITLE
Feat/lazy-load : lazy_load_segment(), vm_get_frame() 구현

### DIFF
--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -63,9 +63,11 @@ struct page {
 };
 
 /* The representation of "frame" */
+// 메타데이터 구조체 (관리용)
 struct frame {
   void *kva;
   struct page *page;
+  struct list_elem elem;
 };
 
 /* The function table for page operations.

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -924,9 +924,16 @@ static bool install_page(void *upage, void *kpage, bool writable) {
  * upper block. */
 
 static bool lazy_load_segment(struct page *page, void *aux) {
-  /* TODO: Load the segment from the file */
-  /* TODO: This called when the first page fault occurs on address VA. */
-  /* TODO: VA is available when calling this function. */
+  struct lazy_load_aux *llaux = (struct lazy_load_aux *)aux;
+  void *kva = page->frame->kva;
+  off_t read_bytes = file_read_at(llaux->file, kva, (off_t)llaux->page_read_bytes,
+                            (off_t)llaux->ofs);
+
+  if (read_bytes != llaux->page_read_bytes){
+    free(aux);
+    return false;
+  }
+  memset(kva + read_bytes, 0, llaux->page_zero_bytes);
   free(aux);
 }
 
@@ -965,8 +972,10 @@ static bool load_segment(struct file *file, off_t ofs, uint8_t *upage,
     aux->page_zero_bytes = page_zero_bytes;
     aux->ofs = ofs;
     if (!vm_alloc_page_with_initializer(VM_ANON, upage, writable,
-                                        lazy_load_segment, aux))
+                                        lazy_load_segment, aux)) {
+      free(aux);
       return false;
+    }
 
     /* Advance. */
     read_bytes -= page_read_bytes;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -91,8 +91,7 @@ struct page *spt_find_page(struct supplemental_page_table *spt UNUSED,
   struct page *page = NULL;
   struct hash_elem *e = NULL;
 
-  page->va = va;
-
+  page->va = pg_round_down(va);
   e = hash_find(&spt->page_table, &page->hash_elem);
   if (e != NULL) {
     page = hash_entry(e, struct page, hash_elem);

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -144,7 +144,19 @@ static struct frame *vm_evict_frame(void) {
  * space.*/
 static struct frame *vm_get_frame(void) {
   struct frame *frame = NULL;
-  /* TODO: Fill this function. */
+  void *kva = palloc_get_page(PAL_USER | PAL_ZERO);
+  if (kva == NULL) {
+    frame = vm_evict_frame();
+  } else {
+    frame = malloc(sizeof(struct frame));
+    if (frame == NULL) {
+      palloc_free_page(kva);
+    }
+    frame->kva = kva;
+    frame->page = NULL;
+    // list_insert(frame->elem,
+    // todo : 나중에 LRU func만들고 list_insert_ordered하기
+  }
 
   ASSERT(frame != NULL);
   ASSERT(frame->page == NULL);
@@ -194,7 +206,6 @@ bool vm_claim_page(void *va UNUSED) {
 static bool vm_do_claim_page(struct page *page) {
   struct frame *frame = vm_get_frame();
 
-  /* Set links */
   frame->page = page;
   page->frame = frame;
 


### PR DESCRIPTION
# 목적
- 프로세스의 세그먼트를 지연 로딩(lazy loading) 방식으로 메모리에 적재하기 위해 lazy_load_segment()를 구현
- 기존 : 기존 `load_segment()`는 ELF 로딩 시점에 모든 페이지를 바로 물리 메모리에 올렸다.
- 현재 구현하는 것 : VM 버전에서는 아직 메모리에 없는 uninit page를 SPT에 등록만 해두고, 실제 접근 시점(page fault 발생) 에 초기화 콜백(`lazy_load_segment()`)을 지정

❗ 참고 : PF 시 흐름 ❗ 
1. 해당 VA에 대한 SPT entry 조회
2. `vm_do_claim_page()` 경로에서 프레임 확보 및 매핑 
3. uninit 초기화 콜백(lazy_load_segment) 호출 🫱  파일에서 읽어 적재

# 접근 전략
## 1. aux로 전달된 lazy_load_aux 구조체 활용
  - file 정보
  - 읽어야 할 byte 수
  - 남은 zero-file 수
  - offset 
 
## 2. page에 인자 활용해서 file-read
  - page구조체에 매핑된 frame의 kva를 활용 -> file read
  - KVA = 실제 물리 프레임의 커널 가상 주소. 여기에 파일 내용을 채운 뒤, 남는 부분은 0으로 초기화.


# 구현부
## `lazy_load_segment` 함수 구현 
```C
// 초기 
static bool lazy_load_segment(struct page *page, void *aux) {
  ...
}
```
- Args 
  1. page
  6. aux (`lazy_load_aux` 구조체) 
  
- `file_read_at` : aux 를 활용해서 file을 읽고 page에 매핑된 frame -> kva에 저장 
- `memset` : 파일을 읽고 남은 페이지 부분은 0으로 초기화

<br>

>  *❓파일 `Load`는 메모리에 하는건데 가상 주소가 왜 필요❓*
> - Pintos에서는 부팅 시 물리 `RAM`을 커널 `VA`에 매핑해둔 상태이다.
> - 따라서 커널 `VA`에 쓰기만해도 `MMU`가 알아서 해당 풀리 `RAM(frame)`에 기록함


## vm_get_frame() 구현
> 프레임 확보 로직 

`vm_do_claim_page`에서 프레임 확보 로직이 쓰임 

1. palloc_get_page(PAL_USER) : User가 사용할 페이지를 커널 영역의 user pool에서 할당받기
2. vm_evict_fraem : 할당 받을 페이지가 부족하면 evict하기
3. malloc(sizeof(struct frame)) : 할당받은 가상 주소를 매핑할 메타데이터 구조체인 frame 구조체 생성 
4. frame->kva = kva : 메타데이터 구조체 frame에 할당받은 커널 가상주소를 매핑

# 트러블 💢 
## 메모리 적재 위치 혼란 
😠 헷갈린 점 - file 읽기 위치 헷갈림
- 결국 가상주소를 활용해서 메모리에 실제 file 내용을 적재해야하는데, 메모리를 어떻게 접근해야되지? 고민을 많이 했고 여기서 시간을 많이 썼다.

✅해결 
- 아래에 고려할점의 '부팅 시 매핑 전략'에 대한 내용을 공부하면서 실제 Pintos에서 어떻게 VA를 통해 실제 메모리와의 접근을 하는지 알게되었다.
- 이러한 메커니즘 속에서 '메모리에 실제 file을 `load`하기 위해서는 Kernel 가상주소를 활용하면 되구나'라는 점을 알았다.

# 고려할 점(option) 🤔 
## 기존 load 코드 
기존 load코드를 보면서 전체적으로 어떻게 구현되어있었구나 생각하면 좋을 것 같다.

## 부팅 시 매핑 전략 (Pintos vs 실제)
>1. *Pintos*
>	- 부팅 시점에 물리 메모리를 통째로 커널 주소 공간에 1:1 매핑
>	- 즉, **커널 가상 주소는 이미 매핑된 영역**
>	- 따라서 `palloc_get_page()`로 page 요청하는 것은 이미 실제 frame과 매핑된 페이지 주소를 주는 것
>	  
>2. *실제*
>	- **일부 지연 매핑** : 커널 가상주소 중 유저 영역 전용 가상주소는 지연 매핑 
>	- 이 외에도 **복잡한 정책으로 최적화** 있는데 이건 pass
