### PR TITLE
Fix : 부팅 로직 및 테스트 파일 실행 단계에서 나오는 버그 수정

### DIFF
--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -899,8 +899,6 @@ static bool setup_stack(struct intr_frame *if_) {
   return success;
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 // 문자열 target을 공백(" ") 기준으로 잘라서 각 토큰(인자)을 argv 배열에
 // 저장하고, 인자의 개수를 반환하는 함수 예: target = "echo hello world" → argv
 // = ["echo", "hello", "world", NULL]
@@ -1031,147 +1029,6 @@ struct file *process_get_file(int fd) {
   return current_thread
       ->FDT[fd];  // 유효한 fd라면 FDT에서 대응되는 파일 포인터 반환
 }
-=======
-=======
->>>>>>> origin/dev
-// // 문자열 target을 공백(" ") 기준으로 잘라서 각 토큰(인자)을 argv 배열에
-// // 저장하고, 인자의 개수를 반환하는 함수 예: target = "echo hello world" →
-// argv
-// // = ["echo", "hello", "world", NULL]
-// static int parse_args(char *target, char *argv[]) {
-//   int argc = 0;  // 인자의 개수를 세기 위한 변수
-//   char *token;
-//   char *save_ptr;  // strtok_r에서 파싱 상태를 유지하기 위한 포인터
-//                    // (reentrant-safe)
-
-//   // 첫 번째 토큰 추출. strtok_r는 문자열을 공백을 기준으로 분리
-//   for (token = strtok_r(target, " ", &save_ptr); token != NULL;
-//        token = strtok_r(NULL, " ",
-//                         &save_ptr))  // 이후 토큰부터는 첫 인자에 NULL 전달
-//   {
-//     argv[argc++] = token;  // 잘라낸 인자를 argv 배열에 저장하고 argc 증가
-//   }
-
-//   // argv는 마지막에 NULL 포인터로 끝나야 exec 계열 함수에서 제대로 처리됨 (C
-//   // 언어 컨벤션)
-//   argv[argc] = NULL;
-
-//   // 최종적으로 인자의 개수를 반환
-//   return argc;
-// }
-
-// // 사용자 프로그램의 스택을 구성하여 인자들을 전달하는 함수
-// static void argument_stack(char *argv[], int argc, struct intr_frame *_if) {
-//   uint64_t rsp_arr[argc];  // 각 인자 문자열의 시작 주소를 저장할 배열
-
-//   // 문자열을 스택에 역순으로 복사
-//   for (int i = argc - 1; i >= 0; i--) {
-//     size_t len = strlen(argv[i]) + 1;        // 문자열 길이 + 널 문자 포함
-//     _if->rsp -= len;                         // 스택 아래로 공간 확보
-//     rsp_arr[i] = _if->rsp;                   // 해당 문자열이 위치한 주소
-//     저장 memcpy((void *)_if->rsp, argv[i], len);  // 스택에 문자열 복사
-//   }
-
-//   // 16바이트 정렬 맞추기 (rsp를 16의 배수로 내림 정렬)
-//   _if->rsp = _if->rsp & ~0xF;  // 하위 4비트 0으로 마스킹 → 16의 배수
-
-//   // x86-64 SysV ABI: 함수 진입 시 rsp % 16 == 8이 되도록 맞춘다.
-//   // 이후에 NULL(8) + argv 포인터들(8*argc) + fake return(8)을 푸시할
-//   예정이므로
-//   // argc가 짝수일 경우 패딩 8바이트를 추가해 총 푸시 바이트가 16으로 나머지
-//   8이
-//   // 되도록 한다.
-//   if ((argc % 2) == 0) {
-//     _if->rsp -= 8;
-//     memset((void *)_if->rsp, 0, 8);
-//   }
-
-//   // NULL sentinel push (argv[argc] = NULL)
-//   _if->rsp -= 8;                                // 포인터 크기만큼 스택
-//   아래로 memset((void *)_if->rsp, 0, sizeof(char *));  // 0으로 채움 (NULL)
-
-//   // argv[i] 포인터들을 역순으로 push
-//   for (int i = argc - 1; i >= 0; i--) {
-//     _if->rsp -= 8;  // 8바이트 공간 확보
-//     memcpy((void *)_if->rsp, &rsp_arr[i],
-//            sizeof(char *));  // 각 문자열의 주소를 복사
-//   }
-
-//   // 가짜 주소 fake return address (unused, just for conventional layout)
-//   // 실제로 쓰이지 않는 가짜 리턴 주소인데, 스택 프레임의 모양을 함수 호출
-//   // 규약에 맞게 유지하려고 형식적으로만 넣은 값
-//   _if->rsp -= 8;
-//   memset((void *)_if->rsp, 0, sizeof(void *));  // 가짜 리턴 주소 = 0
-
-//   // 사용자 프로그램 시작 시 인자 전달을 위한 레지스터 설정
-//   _if->R.rdi = argc;  // 첫 번째 인자: argc
-//   _if->R.rsi =
-//       _if->rsp +
-//       8;  // 두 번째 인자: argv (가짜 리턴 주소 다음부터가 argv[0] 배열)
-// }
-
-// struct thread *get_child_thread(tid_t child_tid) {
-//   struct thread *current_thread =
-//       thread_current();          // 현재 실행 중인 스레드(=부모 스레드)를
-//       가져옴
-//   struct thread *result = NULL;  // 결과를 저장할 포인터
-
-//   // 현재 스레드의 자식 리스트를 순회함
-//   for (struct list_elem *i = list_begin(&current_thread->children);
-//        i != list_end(&current_thread->children); i = i->next) {
-//     // 리스트 요소 i를 thread 구조체로 변환
-//     struct thread *t = list_entry(i, struct thread, child_elem);
-
-//     // 자식 스레드의 tid가 찾고자 하는 child_tid와 같다면
-//     if (t->tid == child_tid) {
-//       result = t;  // 찾은 자식 스레드를 result에 저장
-//       break;       // 더 이상 탐색할 필요 없으므로 반복문 종료
-//     }
-//   }
-
-//   return result;  // 찾았으면 해당 스레드 포인터 반환, 못 찾았으면 NULL 반환
-// }
-
-// int process_add_file(struct file *file) {
-//   // 현재 실행 중인 스레드(=프로세스) 가져오기
-//   struct thread *current_thread = thread_current();
-
-//   // 파일 디스크립터(fd)는 0~2는 이미 예약된 상태(stdin, stdout, stderr)
-//   // 따라서 일반 파일은 3번부터 사용
-//   for (int fd = 3; fd < MAX_FD; fd++) {
-//     // 현재 FDT(File Descriptor Table)에서 비어있는 슬롯 찾기
-//     if (current_thread->FDT[fd] == NULL) {
-//       // 비어 있는 슬롯을 찾으면 해당 위치에 파일 포인터 저장
-//       current_thread->FDT[fd] = file;
-
-//       // 다음 검색할 fd 번호를 갱신
-//       current_thread->next_FD = fd + 1;
-
-//       // 성공적으로 등록한 fd 번호 반환
-//       return fd;
-//     }
-//   }
-
-//   // 모든 슬롯이 차서 더 이상 파일을 열 수 없다면 -1 반환
-//   return -1;
-// }
-
-// struct file *process_get_file(int fd) {
-//   struct thread *current_thread =
-//       thread_current();  // 현재 실행 중인 스레드 포인터 획득
-//   if (current_thread->FDT == NULL) {
-//     return NULL;  // FDT가 아직 준비되지 않았다면 접근할 수 있는 파일이 없음
-//   }
-//   if (fd < 0 || fd >= MAX_FD) {
-//     return NULL;  // 허용 범위를 벗어난 파일 디스크립터는 무효로 간주
-//   }
-//   return current_thread
-//       ->FDT[fd];  // 유효한 fd라면 FDT에서 대응되는 파일 포인터 반환
-// }
-<<<<<<< HEAD
->>>>>>> origin/rebuild
-=======
->>>>>>> origin/dev
 
 /* Adds a mapping from user virtual address UPAGE to kernel
  * virtual address KPAGE to the page table.
@@ -1277,10 +1134,9 @@ static bool setup_stack(struct intr_frame *if_) {
   // Marking : VM_MARKER로 스택 페이지인거 마킹
   // 로드 예약 함수 실행
   if (!vm_alloc_page_with_initializer(VM_MARKER_0 | VM_ANON, stack_bottom, true,
-                                      lazy_load_segment, NULL)) {
+                                      NULL, NULL)) {
     return false;
   }
-
   // page claim
   if (!vm_claim_page(stack_bottom)) {
     return false;
@@ -1289,10 +1145,10 @@ static bool setup_stack(struct intr_frame *if_) {
   // va기준으로 제대로 page구현된거 확인 후 rsp 및 success 조정
   p = pml4_get_page(cur->pml4, stack_bottom);
   if (p != NULL) {
-    if_->rsp = stack_bottom;
+    if_->rsp = USER_STACK;
     success = true;
   }
 
-  return true;
+  return success;
 }
 #endif /* VM */

--- a/pintos/vm/.test_status
+++ b/pintos/vm/.test_status
@@ -1,6 +1,7 @@
 args-dbl-space FAIL
 args-multiple FAIL
 args-none FAIL
+create-bad-ptr PASS
 halt FAIL
 args-many FAIL
 args-single FAIL

--- a/pintos/vm/.test_status
+++ b/pintos/vm/.test_status
@@ -1,6 +1,6 @@
 args-dbl-space FAIL
 args-multiple FAIL
-args-none FAIL
+args-none PASS
 create-bad-ptr PASS
 halt FAIL
 args-many FAIL

--- a/pintos/vm/anon.c
+++ b/pintos/vm/anon.c
@@ -29,14 +29,14 @@ void vm_anon_init(void) {
 /* Initialize the file mapping */
 // 일단 익명이니 0으로?
 bool anon_initializer(struct page *page, enum vm_type type, void *kva) {
-  if (type != VM_ANON) {
+  if (VM_TYPE(type) != VM_ANON) {
     return false;
   }
   /* Set up the handler */
   page->operations = &anon_ops;
 
-  struct anon_page *anon_page = &page->anon;  // 요놈
-  memset(anon_page, 0, sizeof(anon_page));    // 메타데이터를 초기화
+  struct anon_page *anon_page = &page->anon;       // 요놈
+  memset(anon_page, 0, sizeof(struct anon_page));  // 메타데이터를 초기화
   memset(kva, 0, PGSIZE);  // 익명 페이지랑 매핑된 실제 물리값들 초기화
   return true;
 }

--- a/pintos/vm/anon.c
+++ b/pintos/vm/anon.c
@@ -38,6 +38,7 @@ bool anon_initializer(struct page *page, enum vm_type type, void *kva) {
   struct anon_page *anon_page = &page->anon;       // 요놈
   memset(anon_page, 0, sizeof(struct anon_page));  // 메타데이터를 초기화
   memset(kva, 0, PGSIZE);  // 익명 페이지랑 매핑된 실제 물리값들 초기화
+  page->writable = true;
   return true;
 }
 

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -79,7 +79,6 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
 
     /* uninit 페이지로 초기화 후 spt테이블 삽입 */
     uninit_new(page, upage, init, type, aux, initializer);
-    page->writable = writable;
 
     if (!spt_insert_page(spt, page)) {
       free(page);

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -98,7 +98,7 @@ struct page *spt_find_page(struct supplemental_page_table *spt, void *va) {
   // va만 삽입한 가짜 hash_elem을 보내는 방식
   /* TODO: Fill this function. */
   /* va만 저장할 껍데기 페이지 */
-  struct page *temp_page;
+  struct page temp_page;
 
   /* 찾을 페이지의 elem*/
   struct hash_elem *e = NULL;
@@ -106,8 +106,8 @@ struct page *spt_find_page(struct supplemental_page_table *spt, void *va) {
   /* e를 이용해 복구될 페이지 */
   struct page *page = NULL;
 
-  temp_page->va = pg_round_down(va);
-  e = hash_find(&spt->page_table, &temp_page->hash_elem);
+  temp_page.va = pg_round_down(va);
+  e = hash_find(&spt->page_table, &temp_page.hash_elem);
   if (e != NULL) {
     page = hash_entry(e, struct page, hash_elem);
   }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -79,6 +79,7 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
 
     /* uninit 페이지로 초기화 후 spt테이블 삽입 */
     uninit_new(page, upage, init, type, aux, initializer);
+    page->writable = writable;
 
     if (!spt_insert_page(spt, page)) {
       free(page);

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -49,8 +49,7 @@ static struct frame *vm_evict_frame(void);
 bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
                                     bool writable, vm_initializer *init,
                                     void *aux) {
-  // 외부에서 uninit type 날리면 안됨.
-  ASSERT(VM_TYPE(type) != VM_UNINIT)
+  // 외부에서 uninit type 날리면 안됨. ASSERT(VM_TYPE(type) != VM_UNINIT)
 
   struct supplemental_page_table *spt = &thread_current()->spt;
 
@@ -80,6 +79,8 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
 
     /* uninit 페이지로 초기화 후 spt테이블 삽입 */
     uninit_new(page, upage, init, type, aux, initializer);
+    page->writable = writable;
+
     if (!spt_insert_page(spt, page)) {
       free(page);
       goto err;
@@ -161,17 +162,17 @@ static struct frame *vm_get_frame(void) {
   struct frame *frame = NULL;
   void *kva = palloc_get_page(PAL_USER | PAL_ZERO);
   if (kva == NULL) {
-    frame = vm_evict_frame();
-  } else {
-    frame = malloc(sizeof(struct frame));
-    if (frame == NULL) {
-      palloc_free_page(kva);
-    }
-    frame->kva = kva;
-    frame->page = NULL;
-    // list_insert(frame->elem,
-    // todo : 나중에 LRU func만들고 list_insert_ordered하기
+    return vm_evict_frame();
   }
+
+  frame = malloc(sizeof(struct frame));
+  if (frame == NULL) {
+    palloc_free_page(kva);
+  }
+  frame->kva = kva;
+  frame->page = NULL;
+  // list_insert(frame->elem,
+  // todo : 나중에 LRU func만들고 list_insert_ordered하기
 
   ASSERT(frame != NULL);
   ASSERT(frame->page == NULL);
@@ -190,7 +191,7 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr, bool user,
   /* addr 없으면 false*/
   if (addr == NULL) return false;
   /* 유저영역주소가 아니라면 (커널) false)*/
-  if (!user) return false;
+  if (!is_user_vaddr(addr)) return false;
   /* PTE가 있는데 들어왔다면 false */
   if (!not_present) return false;
 
@@ -223,8 +224,8 @@ bool vm_claim_page(void *va) {
   if (va == NULL || is_kernel_vaddr(va)) {
     return false;
   }
-
-  page = spt_find_page(thread_current()->pml4, va);
+  // spt를 넣어야함.
+  page = spt_find_page(&thread_current()->spt, va);
   if (page == NULL) {
     return false;
   }
@@ -245,7 +246,9 @@ static bool vm_do_claim_page(struct page *page) {
   page->frame = frame;
 
   /* TODO: Insert page table entry to map page's VA to frame's PA. */
-  pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable);
+  if (!pml4_set_page(thread_current()->pml4, page->va, frame->kva,
+                     page->writable))
+    return false;
 
   return swap_in(page, frame->kva);
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -161,15 +161,15 @@ static struct frame *vm_get_frame(void) {
   struct frame *frame = NULL;
   void *kva = palloc_get_page(PAL_USER | PAL_ZERO);
   if (kva == NULL) {
-    return vm_evict_frame();
+    frame = vm_evict_frame();
+  } else {
+    frame = malloc(sizeof(struct frame));
+    if (frame == NULL) {
+      palloc_free_page(kva);
+    }
+    frame->kva = kva;
+    frame->page = NULL;
   }
-
-  frame = malloc(sizeof(struct frame));
-  if (frame == NULL) {
-    palloc_free_page(kva);
-  }
-  frame->kva = kva;
-  frame->page = NULL;
   // list_insert(frame->elem,
   // todo : 나중에 LRU func만들고 list_insert_ordered하기
 

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -121,7 +121,7 @@ bool spt_insert_page(struct supplemental_page_table *spt, struct page *page) {
   struct hash_elem *result_elem =
       hash_insert(&spt->page_table, &page->hash_elem);
 
-  if (result_elem == &page->hash_elem) {
+  if (result_elem == NULL) {
     succ = true;
   }
   return succ;


### PR DESCRIPTION
## 📌 목적
테스트 파일 성공을 위해 

## 📌 접근 전략
브레이킹 포인트를 통한 디버그

## 📌 구현부

### 🌵 `process.c` - setup_stack  
1.  `vm_alloc~`(page_load예약하는)  함수 인자 전달 수정 
  - `lazy_load_segment` -> `NULL`
  - 이유 : stack페이지는 file기반이 아니므로 실제 file을 메모리에 올리는 `lazy_load_segment` 실행기를 `NULL`로 수정

2. `rsp` 수정 
- 올바르지 않은 stack pointer 대입 수정 

### 🌵`anon.c` - anon_initializer
1. 타입 검증 방식 수정 - 기존 메크로 사용
- 기존 : `if (type != VM_ANON)`
- 수정 : `if (VM_TYPE(type) != VM_ANON)`
- 스택용 익명 페이지는 `VM_ANON | VM_MARKER_0`로 저장해서 flage들을 합쳐서 표현했다. 근데 단순 비교 시 `VM_ANON`판단을 잘못할 수 있음 
- VM_TYPE(type) ((type) & 0x7) 메크로를 사용함으로써 단순 하위 3bit만 추츨해서 실제 메인 타입을 판별 가능 (상위 비트는 짤라냄)

2. memset 시 잘못된 사이즈 선언 수정
3. page->writable = true 로 되게 수정 

### 🌵`vm.c` - `spt_find_page`
- temp_page 수정 : 포인터 -> 일반 변수 
- 

### 🌵`vm.c` - `spt_insert_page`
비교 로직 오류 수정 

### 🌵`vm.c` - `vm_claim_page` 
잘못된 인자 전달 수정 pml4 -> spt 

## 📌 트러블슈팅
잘못된 setup_stack 로직 개념으로 인해 디버깅 어려움 겪었다.


## 📌 후기 (Optional)
비트 마스킹을 활용한 메크로를 완벽히 이해하기 위해 C공부를 좀 더 해야 할 것 같다.
빠르게 작성하고 넘어가고 디버그 단계에서 고치며 나아간다는 생각이 컸었는데 이번 디버깅은 꽤나 시간이 걸렸다. 디버깅 시간을 절약하기 위해서라도 앞으로 조금 신경써서 코드를 작성해야 할 것 같다.